### PR TITLE
Replaced installation of gcovr (now 7.0) with the recommended approach

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,8 @@ ARG DEBIAN_FRONTEND=noninteractive
 ENV TZ=Europe/Copenhagen
 
 # Install gpg by itself as it needs recommended packages (at least dirmngr).
-RUN deps='sudo curl bzip2 ca-certificates wget zip unzip tzdata flex bison graphviz make libc6-dev patch python3 python3-pip python3-virtualenv python3-build gcovr cmake git gcc g++ gcc-multilib g++-multilib libboost-log1.74.0 dos2unix ruby ruby-dev clang valgrind texlive-bibtex-extra default-jre nodejs python3-yaml gdb' \
-    && apt-get update \
+RUN deps='sudo curl bzip2 ca-certificates wget zip unzip tzdata flex bison graphviz make libc6-dev patch python3 python3-pip python3-virtualenv python3-build cmake git gcc g++ gcc-multilib g++-multilib libboost-log1.74.0 dos2unix ruby ruby-dev clang valgrind texlive-bibtex-extra default-jre nodejs python3-yaml gdb' \
+    && apt-get update --fix-missing \
     && apt-get install -y --no-install-recommends $deps \
     && apt-get install -y gpg \
     && rm -rf /var/lib/apt/lists/*
@@ -57,6 +57,9 @@ RUN wget -O archive.tar.bz2 "https://developer.arm.com/-/media/Files/downloads/g
     rm archive.tar.bz2
 
 ENV PATH=/opt/gcc-arm-none-eabi-10.3-2021.10/bin:$PATH
+
+# GCOVR
+RUN pip install gcovr==7.0
 
 RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 RUN groupadd -g $GID -o build


### PR DESCRIPTION
Also added --fix-missing to address an issue during apt-get update.

https://gcovr.com/en/stable/installation.html