### PR TITLE
tridentiot/z-wave-sdk#567: pyelftools library

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,22 +46,22 @@ RUN wget -q $DOXYGEN_URL -O /tmp/doxygen.zip \
     && cd /tmp/doxygen*/ \
     && mkdir build && cd build \
     && cmake .. \
-    && N_CPU_CORES=`cat /proc/cpuinfo | grep processor | wc -l` \
+    && N_CPU_CORES=$(nproc) \
     && make -j $N_CPU_CORES && make install \
     && rm -rf /tmp/doxygen*
 
 # ARM GCC
 RUN cd /tmp/ && \
-    wget https://developer.arm.com/-/media/Files/downloads/gnu/12.3.rel1/binrel/arm-gnu-toolchain-12.3.rel1-x86_64-arm-none-eabi.tar.xz && \
-    wget https://developer.arm.com/-/media/Files/downloads/gnu/12.3.rel1/binrel/arm-gnu-toolchain-12.3.rel1-x86_64-arm-none-eabi.tar.xz.sha256asc && \
-    sha256sum --check arm-gnu-toolchain-12.3.rel1-x86_64-arm-none-eabi.tar.xz.sha256asc && \
-    tar xJf arm-gnu-toolchain-12.3.rel1-x86_64-arm-none-eabi.tar.xz -C /opt && \
+    wget https://developer.arm.com/-/media/Files/downloads/gnu/13.2.rel1/binrel/arm-gnu-toolchain-13.2.rel1-x86_64-arm-none-eabi.tar.xz && \
+    wget https://developer.arm.com/-/media/Files/downloads/gnu/13.2.rel1/binrel/arm-gnu-toolchain-13.2.rel1-x86_64-arm-none-eabi.tar.xz.sha256asc && \
+    sha256sum --check arm-gnu-toolchain-13.2.rel1-x86_64-arm-none-eabi.tar.xz.sha256asc && \
+    tar xJf arm-gnu-toolchain-13.2.rel1-x86_64-arm-none-eabi.tar.xz -C /opt && \
     rm arm-gnu-toolchain*
 
-ENV PATH=/opt/arm-gnu-toolchain-12.3.rel1-x86_64-arm-none-eabi/bin:$PATH
+ENV PATH=/opt/arm-gnu-toolchain-13.2.Rel1-x86_64-arm-none-eabi/bin:$PATH
 
-# GCOVR
-RUN pip install gcovr==7.0
+# GCOVR and pyelftools
+RUN pip install gcovr==7.0 pyelftools==0.32
 
 RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 RUN groupadd -g $GID -o build


### PR DESCRIPTION
Include the Python library pyelftools to calculate the FLASH and RAM usage. 
Update the gcc toolchain to version 13.2.